### PR TITLE
added perfect forwarding to the existing combinators

### DIFF
--- a/combinators.hpp
+++ b/combinators.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <functional>
+#include <utility>
 
 namespace combinators {
 
@@ -10,13 +11,17 @@ namespace combinators {
 /////////////////
 
 // B (The Bluebird)
-auto _b = [](auto f, auto g) { return [=](auto x) { return f(g(x)); }; };
+auto _b = [](auto f, auto g) { return [=](auto&& x) { return f(g(std::forward<decltype(x)>(x))); }; };
 
 // Phi (The Phoenix)
-auto _phi = [](auto f, auto g, auto h) { return [=](auto x) { return g(f(x), h(x)); }; };
+auto _phi = [](auto f, auto g, auto h) {
+    return [=](auto&& x) { return g(f(std::forward<decltype(x)>(x)), h(std::forward<decltype(x)>(x))); };
+};
 
 // Psi (The Psi Bird)
-auto _psi = [](auto f, auto g) { return [=](auto x, auto y) { return f(g(x), g(y)); }; };
+auto _psi = [](auto f, auto g) {
+    return [=](auto&& x, auto&& y) { return f(g(std::forward<decltype(x)>(x)), g(std::forward<decltype(y)>(y))); };
+};
 
 /////////////////////////////////////////////
 // more convenient binary/unary operations //


### PR DESCRIPTION
Cool idea for a library! Was playing around with it a little bit after watching your The Twin Algorithms talk and found this small "issue", though I'm not sure if you want to call it that.
By always passing the argument by value in the resulting combined function, things like these don't work

```C++
int a{5};
auto modifying_function = [](auto& x){x++; return x;};
auto identity = [](auto x){return std::forward<decltype(x)>(x);};
auto combined = combinators::_b(identity, modifying_function);
combined(x);
assert(a == 6); //this will fail, a will be 5 since combined is capturing by value.
```

Again, this behavior be intended, so feel free to reject!

Best wishes,
Boris