### PR TITLE
added perfect forwarding to the existing combinators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cmake-build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,15 @@
+cmake_minimum_required(VERSION 3.12)
+
+# Define your project
+project(Blackbird VERSION 1.0)
+
+# Set C++17 as the standard for the entire project
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Add the blackbird library
 add_library(blackbird INTERFACE)
 target_include_directories(blackbird INTERFACE .)
+
+# Add the "test_dir" subdirectory
+add_subdirectory(test)

--- a/combinators.hpp
+++ b/combinators.hpp
@@ -3,6 +3,9 @@
 
 #include <functional>
 
+#define FWD(x) std::forward<decltype(x)>(x)
+#define ARG auto&&
+
 namespace combinators {
 
 /////////////////
@@ -10,72 +13,72 @@ namespace combinators {
 /////////////////
 
 // B (The Bluebird)
-auto _b = [](auto f, auto g) { return [=](auto x) { return f(g(x)); }; };
+auto _b = [](auto f, auto g) { return [=](ARG x) { return f(g(FWD(x))); }; };
 
 // BB (The Bluebird^2)
-auto _bb = [](auto f, auto g, auto h) { return [=](auto x) { return f(g(h(x))); }; };
+auto _bb = [](auto f, auto g, auto h) { return [=](ARG x) { return f(g(h(FWD(x)))); }; };
 
 // BBB (The Bluebird^3)
-auto _bbb = [](auto f, auto g, auto h, auto i) { return [=](auto x) { return f(g(h(i(x)))); }; };
+auto _bbb = [](auto f, auto g, auto h, auto i) { return [=](ARG x) { return f(g(h(i(FWD(x))))); }; };
 
 // B1 (The Blackbird)
-auto _b1 = [](auto f, auto g) { return [=](auto x, auto y) { return f(g(x, y)); }; };
+auto _b1 = [](auto f, auto g) { return [=](ARG x, ARG y) { return f(g(FWD(x), FWD(y))); }; };
 
 // C (The Cardinal) aka `flip` in Haskell
-auto _c = [](auto f) { return [=](auto x, auto y) { return f(y, x); }; };
+auto _c = [](auto f) { return [=](ARG x, ARG y) { return f(FWD(y), FWD(x)); }; };
 
 // K (Kestrel)
-auto _l_ = [](auto x, auto y) { return x; };
+auto _l_ = [](ARG x, ARG y) { return FWD(x); };
 
 // KI
-auto _r_ = [](auto x, auto y) { return y; };
+auto _r_ = [](ARG x, ARG y) { return FWD(y); };
 
 // Phi (The Phoenix)
-auto _phi = [](auto f, auto g, auto h) { return [=](auto x) { return g(f(x), h(x)); }; };
+auto _phi = [](auto f, auto g, auto h) { return [=](ARG x) { return g(f(FWD(x)), h(FWD(x))); }; };
 
 // Phi1 (The Pheasant)
-auto _phi1_ = [](auto f, auto g, auto h) { return [=](auto x, auto y) { return g(f(x, y), h(x, y)); }; };
+auto _phi1_ = [](auto f, auto g, auto h) { return [=](ARG x, ARG y) { return g(f(FWD(x), FWD(y)), h(FWD(x), FWD(y))); }; };
 
 // Psi (The Psi Bird)
-auto _psi = [](auto f, auto g) { return [=](auto x, auto y) { return f(g(x), g(y)); }; };
+auto _psi = [](auto f, auto g) { return [=](ARG x, ARG y) { return f(g(FWD(x)), g(FWD(y))); }; };
 
 // W (The Warbler)
-auto _w = [](auto f) { return [=](auto x) { return f(x, x); }; };
+auto _w = [](auto f) { return [=](ARG x) { return f(FWD(x), FWD(x)); }; };
 
 /////////////////////////////////////////////
 // more convenient binary/unary operations //
 /////////////////////////////////////////////
 
-auto _eq    = [](auto x) { return [x](auto y) { return x == y; }; };
+auto _eq    = [](ARG x) { return [x](ARG y) { return FWD(x) == FWD(y); }; };
 auto _eq_   = std::equal_to{};
 auto _neq_  = std::not_equal_to{};
-auto _lt    = [](auto x) { return [x](auto y) { return x > y; }; };
-auto lt_    = [](auto x) { return [x](auto y) { return y < x; }; };
+auto _lt    = [](ARG x) { return [x](ARG y) { return FWD(x) > FWD(y); }; };
+auto lt_    = [](ARG x) { return [x](ARG y) { return FWD(y) < FWD(x); }; };
 auto _lt_   = std::less{};
 auto _lte_  = std::less_equal{};
 auto _gt_   = std::greater{};
-auto _gte   = [](auto x) { return [x](auto y) { return x >= y; }; };
+auto _gte   = [](ARG x) { return [x](ARG y) { return FWD(x) >= FWD(y); }; };
 auto _gte_  = std::greater_equal{};
-auto _plus  = [](auto x) { return [x](auto y) { return x + y; }; };
+auto _plus  = [](ARG x) { return [x](ARG y) { return FWD(x) + FWD(y); }; };
 auto _plus_ = std::plus{};
-auto _mul   = [](auto x) { return [x](auto y) { return x * y; }; };
+auto _mul   = [](ARG x) { return [x](ARG y) { return FWD(x) * FWD(y); }; };
 auto _mul_  = std::multiplies{};
-auto _sub   = [](auto x) { return [x](auto y) { return x - y; }; };
-auto sub_   = [](auto x) { return [x](auto y) { return y - x; }; };
+auto _sub   = [](ARG x) { return [x](ARG y) { return FWD(x) - FWD(y); }; };
+auto sub_   = [](ARG x) { return [x](ARG y) { return FWD(y) - FWD(x); }; };
 auto _sub_  = std::minus{};
-auto _mod   = [](auto x) { return [x](auto y) { return x % y; }; };
-auto mod_   = [](auto x) { return [x](auto y) { return y % x; }; };
+auto _mod   = [](ARG x) { return [x](ARG y) { return FWD(x) % FWD(y); }; };
+auto mod_   = [](ARG x) { return [x](ARG y) { return FWD(y) % FWD(x); }; };
 auto _mod_  = std::modulus{};
 auto _or_   = std::logical_or{};
 auto _and_  = std::logical_and{};
 auto _not   = std::logical_not{};
-auto _min_  = [](auto a, auto b) { return std::min(a, b); };
-auto _max_  = [](auto a, auto b) { return std::max(a, b); };
-auto _fst   = [](auto t) { return std::get<0>(t); };
-auto _snd   = [](auto t) { return std::get<1>(t); };
-auto _bool  = [](auto e) { return static_cast<bool>(e); };
+auto _min_  = [](ARG a, ARG b) { return std::min(FWD(a), FWD(b)); };
+auto _max_  = [](ARG a, ARG b) { return std::max(FWD(a), FWD(b)); };
+auto _fst   = [](ARG t) { return std::get<0>(t); };
+auto _snd   = [](ARG t) { return std::get<1>(t); };
+auto _bool  = [](ARG e) { return static_cast<bool>(e); };
 
-auto _odd  = [](auto x) { return (x % 2) == 1; };
-auto _even = [](auto x) { return (x % 2) == 0; };
+auto _odd  = [](ARG x) { return (x % 2) == 1; };
+auto _even = [](ARG x) { return (x % 2) == 0; };
 
 }  // namespace combinators

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(EXE "test_exe")
+add_executable(${EXE} test.cpp)
+target_link_libraries(${EXE} PRIVATE blackbird)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+#include "combinators.hpp"
+
+int main() {
+    int a{5};
+    auto modifying_function = [](auto& x){x++; return x;};
+    auto identity = [](auto x){return std::forward<decltype(x)>(x);};
+    auto combined = combinators::_b(identity, modifying_function);
+    combined(a);
+    std::cout << a;
+}


### PR DESCRIPTION
```
❯ git restore --source=main combinators.hpp
❯ pushd cmake-build && cmake ..; popd; cmake --build cmake-build
~/Desktop/blackbird/cmake-build ~/Desktop/blackbird
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ari/Desktop/blackbird/cmake-build
~/Desktop/blackbird
Consolidate compiler generated dependencies of target test_exe
[ 50%] Building CXX object test/CMakeFiles/test_exe.dir/test.cpp.o
[100%] Linking CXX executable test_exe
[100%] Built target test_exe

❯ ./cmake-build/test/test_exe
5
# WRONG

❯ git restore combinators.hpp
❯ pushd cmake-build && cmake ..; popd; cmake --build cmake-build
~/Desktop/blackbird/cmake-build ~/Desktop/blackbird
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ari/Desktop/blackbird/cmake-build
~/Desktop/blackbird
Consolidate compiler generated dependencies of target test_exe
[ 50%] Building CXX object test/CMakeFiles/test_exe.dir/test.cpp.o
[100%] Linking CXX executable test_exe
[100%] Built target test_exe

❯ ./cmake-build/test/test_exe
6
# RIGHT
```

Test copied from @boris-kuz